### PR TITLE
Update wa-system/design/templates/Design.html

### DIFF
--- a/wa-system/design/templates/Design.html
+++ b/wa-system/design/templates/Design.html
@@ -112,6 +112,7 @@
 
         $('.wa-theme-globalnav').on('mouseover', function () {
             $('#wa-theme-list').css('display', '');
+            $('#wa-app').css('overflow', 'visible');
         });
 
         var waDesignHash = function (url) {
@@ -171,7 +172,14 @@
                 if (set_active_only) {
                     return false;
                 }
-                var hash = location.hash;
+                
+                var current_action = $('#wa-design-menu > li.selected').data('action');
+                if (typeof(current_action) !== 'undefined'){
+                    var hash = href+'&action='+current_action;
+                } else {
+                    var hash = href;
+                }
+                
                 if (hash.indexOf('theme=') !== -1) {
                     if (hash.indexOf('action=settings') !== -1) {
                         if (!params['route']) {


### PR DESCRIPTION
Баг1. при длинном списке доменов, этот список обрезается div-ом #wa-apps(overflow: hidden). 
исправлено на overflow: visible при наведении на .wa-theme-globalnav

Баг2. в магазине(и других приложениях), при клике во вкладке Витрина->Дизайн на домен в списке( НЕ первый), первый клик ВСЕГДА переключает на некий "дефолтный" домен (подозреваю что первый в routing.php) и только при втором клике идёт переход на нужный домен. При большом списке, когда нужный домен в самом конце, мотать список еще раз - очень напрягает.
Исправлено.
